### PR TITLE
Feat/wselorpad

### DIFF
--- a/configs/ucf_i3d.yaml
+++ b/configs/ucf_i3d.yaml
@@ -3,6 +3,7 @@ dataset: 'ucf-crime'
 backbone: 'i3d'
 feature_size: 1024
 n_crop: 10
+seg: 'itp' #seq
 feature_path: 'data/ucf-crime/i3d'
 data_file_train: 'data/ucf-crime/ucf-crime.training.csv'
 data_file_test: 'data/ucf-crime/ucf-crime.testing.csv'

--- a/configs/xd_i3d.yaml
+++ b/configs/xd_i3d.yaml
@@ -3,6 +3,7 @@ dataset: 'xd-violence'
 backbone: 'i3d'
 feature_size: 1024
 n_crop: 5
+seg: 'itp' #seq
 feature_path: 'data/xd-violence/i3d'
 data_file_train: 'data/xd-violence/xd-violence.training.csv'
 data_file_test: 'data/xd-violence/xd-violence.testing.csv'

--- a/models.py
+++ b/models.py
@@ -22,7 +22,6 @@ class Memory_Unit(Module):
         if self.memory_block is not None:
             self.memory_block.data.uniform_(-stdv, stdv)
     
-       
     def forward(self, data):  ####data size---> B,T,D       K,V size--->K,D
         attention = self.sig(torch.einsum('btd,kd->btk', data, self.memory_block) / (self.dim**0.5))   #### Att---> B,T,K
         temporal_att = torch.topk(attention, self.nums//16+1, dim = -1)[0].mean(-1)
@@ -112,7 +111,7 @@ class URDMU(Module):
 
             _, P_index = torch.topk(N_Aatt, t//16 + 1, dim=-1)
             positivte_nx = torch.gather(A_x, 1, P_index.unsqueeze(2).expand([-1, -1, x.size(-1)])).mean(1).reshape(b//2,n,-1).mean(1)
-               
+
             triplet_margin_loss = self.triplet(norm(anchor_nx), norm(positivte_nx), norm(negative_ax))
 
             N_aug_mu = self.encoder_mu(N_aug)
@@ -127,7 +126,7 @@ class URDMU(Module):
             kl_loss = self.latent_loss(N_aug_mu, N_aug_var)
             A_Naug = self.encoder_mu(A_Naug)
             N_Aaug = self.encoder_mu(N_Aaug)
-          
+
             distance = torch.relu(100 - torch.norm(negative_ax_new, p=2, dim=-1) + torch.norm(anchor_nx_new, p=2, dim=-1)).mean()
             x = torch.cat((x, (torch.cat([N_aug_new + A_Naug, A_aug_new + N_Aaug], dim=0))), dim=-1)
             pre_att = self.cls_head(x).reshape((b, n, -1)).mean(1)
@@ -151,7 +150,6 @@ class URDMU(Module):
 
             x = torch.cat([x, A_aug + N_aug], dim=-1)
             pre_att = self.cls_head(x).reshape((b, n, -1)).mean(1)
-
 
             return {"video_scores":pre_att}
 

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,8 @@ import os
 import json
 import random
 import torch
+import torch.nn as nn
+import torch.nn.functional as F
 from torch.utils.collect_env import get_pretty_env_info
 import numpy as np
 from termcolor import colored
@@ -41,8 +43,7 @@ def gaussian_kernel_mining(args, score, point_label):
     abn_ratio = args.alpha
     for b in range(point_label.shape[0]):
         abn_idx = torch.nonzero(point_label[b]).squeeze(1)
-        if len(abn_idx) == 0:
-            continue
+        if len(abn_idx) == 0: continue
 
         # most left
         if abn_idx[0] > 0:
@@ -51,8 +52,7 @@ def gaussian_kernel_mining(args, score, point_label):
                 abn_thresh = abn_ratio * score[b, abn_idx[0]]
                 if score[b, j] >= abn_thresh:
                     abn_snippet[b, j] = 1
-                else:
-                    break
+                else: break
 
         # most right
         if abn_idx[-1] < (point_label.shape[1]-1):
@@ -61,8 +61,7 @@ def gaussian_kernel_mining(args, score, point_label):
                 abn_thresh = abn_ratio * score[b, abn_idx[-1]]
                 if score[b, j] >= abn_thresh:
                     abn_snippet[b, j] = 1
-                else:
-                    break
+                else: break
             
         # between
         for i in range(len(abn_idx)-1):
@@ -73,14 +72,12 @@ def gaussian_kernel_mining(args, score, point_label):
                 abn_thresh = abn_ratio * score[b, abn_idx[i]]
                 if score[b, j] >= abn_thresh:
                     abn_snippet[b, j] = 1
-                else:
-                    break
+                else: break
             for j in range(abn_idx[i+1]-1, abn_idx[i], -1):
                 abn_thresh = abn_ratio * score[b, abn_idx[i+1]]
                 if score[b, j] >= abn_thresh:
                     abn_snippet[b, j] = 1
-                else:
-                    break
+                else: break
     return abn_snippet
 
 def temporal_gaussian_splatting(point_label, distribution='normal', params=None):
@@ -124,6 +121,146 @@ def temporal_gaussian_splatting(point_label, distribution='normal', params=None)
         distribution_weight[b, :] = temp_weight
 
     return distribution_weight
+
+
+class GlanceLoss(nn.Module):
+    def __init__(self, args): 
+        super().__init__()
+        
+        self.dvc = args.device
+        self.abn_ratio = args.alpha
+        self.sigma = torch.tensor(args.sigma)
+        self.min_mining_step = args.min_mining_step
+
+        self.bce = nn.BCELoss(reduction='none')  # 4flexibility
+        
+    def gaussian_kernel_mining(self, score, point_label, seqlen=None):
+        abn_snippet = point_label.clone().detach()
+        bs, max_len = point_label.shape
+        
+        for b in range(bs):
+            valid_len = max_len
+            if seqlen is not None:
+                valid_len = min(seqlen[b].item(), max_len)
+            
+            abn_idx = torch.nonzero(point_label[b]).squeeze(1)
+            if len(abn_idx.shape) == 0 and abn_idx.numel() > 0:  # Handle single index case
+                abn_idx = abn_idx.unsqueeze(0)
+            if abn_idx.numel() == 0: continue
+            #if len(abn_idx) == 0: continue   
+            
+            # Process most left boundary
+            if abn_idx[0] > 0:
+                for j in range(abn_idx[0]-1, -1, -1):
+                    abn_thresh = self.abn_ratio * score[b, abn_idx[0]]
+                    if score[b, j] >= abn_thresh:
+                        abn_snippet[b, j] = 1
+                    else: break
+
+            # Process most right boundary (respect sequence length)
+            if abn_idx[-1] < (valid_len-1):
+                for j in range(abn_idx[-1]+1, valid_len):
+                    abn_thresh = self.abn_ratio * score[b, abn_idx[-1]]
+                    if score[b, j] >= abn_thresh:
+                        abn_snippet[b, j] = 1
+                    else: break
+                
+            # Process between abnormal points
+            for i in range(len(abn_idx)-1):
+                if abn_idx[i+1] - abn_idx[i] <= 1:
+                    continue
+                    
+                # Forward pass
+                for j in range(abn_idx[i]+1, abn_idx[i+1]):
+                    abn_thresh = self.abn_ratio * score[b, abn_idx[i]]
+                    if score[b, j] >= abn_thresh:
+                        abn_snippet[b, j] = 1
+                    else: break
+                        
+                # Backward pass
+                for j in range(abn_idx[i+1]-1, abn_idx[i], -1):
+                    abnloss_fx_thresh = self.abn_ratio * score[b, abn_idx[i+1]]
+                    if score[b, j] >= abn_thresh:
+                        abn_snippet[b, j] = 1
+                    else: break
+                        
+        return abn_snippet
+
+    def temporal_gaussian_splatting(self, point_label, distribution='normal', params=None, seqlen=None):
+        point_label = point_label.clone().detach().cpu()
+        bs, max_len = point_label.shape
+        distribution_weight = torch.zeros_like(point_label)
+        
+        for b in range(bs):
+            N = max_len
+            if seqlen is not None:
+                N = min(seqlen[b].item(), max_len)
+                if N == 0: continue
+            
+            #point_label = point_label[b, :N]
+            abn_idx = torch.nonzero(point_label[b]).squeeze(1)
+            if len(abn_idx.shape) == 0 and abn_idx.numel() > 0:  # Handle single index case
+                abn_idx = abn_idx.unsqueeze(0)
+            if abn_idx.numel() == 0: continue
+
+            temp_weight = torch.zeros([len(abn_idx), N])
+            for i, point in enumerate(abn_idx):
+                # Normalize to [-1, 1] range within valid sequence
+                i_arr = torch.arange(N, dtype=torch.float32)
+                if N > 1:
+                    h_i = 2 * (i_arr - 1) / (N - 1) - 1
+                    h_p = 2 * (point - 1) / (N - 1) - 1
+                else:
+                    h_i = h_p = torch.zeros(1)
+
+                # Calculate weights based on distribution
+                if distribution == 'normal':
+                    weight = torch.exp(-(h_i - h_p) ** 2 / (2 * params['sigma']**2)) / (params['sigma'] * (2 * torch.pi)**0.5)
+                elif distribution == 'cauchy':
+                    weight = 1 / (1 + ((h_i - h_p) / params['gamma'])**2) / (torch.pi * params['gamma'])
+                elif distribution == 'laplace':
+                    weight = 0.5 * torch.exp(-torch.abs(h_i - h_p) / params['b']) / params['b']
+                else:
+                    raise ValueError(f"Unsupported distribution: {distribution}")
+
+                if torch.min(weight) != torch.max(weight):
+                    weight = (weight - torch.min(weight)) / (torch.max(weight) - torch.min(weight))
+                else:
+                    weight = torch.ones_like(weight)
+                    
+                temp_weight[i, :] = weight
+
+            temp_weight = torch.max(temp_weight, dim=0)[0]
+            
+            if torch.min(temp_weight) != torch.max(temp_weight):
+                temp_weight = (temp_weight - torch.min(temp_weight)) / (torch.max(temp_weight) - torch.min(temp_weight))
+            
+            distribution_weight[b, :N] = temp_weight
+
+        return distribution_weight
+
+    def forward(self, abn_scores, abn_pnt_lbl, step, abn_seqlen = None):
+        
+        # Gaussian Mining
+        abn_kernel = self.gaussian_kernel_mining(
+            abn_scores.detach().cpu(), 
+            abn_pnt_lbl
+        )
+        # Temporal Gaussian Splatting
+        if step < self.min_mining_step:
+            rendered_score = self.temporal_gaussian_splatting(
+                abn_pnt_lbl, 
+                'normal', 
+                params={'sigma': self.sigma}
+            )
+        else:
+            rendered_score = self.temporal_gaussian_splatting(
+                abn_kernel, 
+                'normal', 
+                params={'sigma': self.sigma}
+            )
+        loss = self.bce(abn_scores, rendered_score.to(self.dvc)).mean()
+        return loss
 
 
 def save_best_record(test_info, file_path, metric):


### PR DESCRIPTION
Hi,

While implementing the Glance supervision/optimization in zuble/uws4vad@0cc126775afc7b0a4f424a805dfe671fcc42ee0d, identified an issue with handling point labels correctly in different segmentation pipelines.

The current implementation works for interpolated features, but a misalignment between features and point labels when using SelOrPad with both random and uniform extraction. For example, from a 350-length video features, with a point anomaly at idx 300, selected sequence must contain the point anomaly, therefore the start point (for random extract) must be set around some boundaries, in case of uniform extract still have no idea.  

Solution could be:
- Modify SelOrPad to return the sampled idxs along with the processed features
- Enhance _get_point_label_ to consider only points that fall within the selected segment
OR
- Modify SelOrPad to accept points as argument, so sampled idxs contain at least one anomaly
and then
- Update the Glance loss to handle both interpolation and SelOrPad methods

Reorganized some of the code to better unify the handling of both data processing methods, making the solution more maintainable.

Congratulations on the excellent work @pipixin321 :)
